### PR TITLE
docs: fix repository clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This script automates the installation and configuration of **dwm** (Dynamic Win
 ## Installation Instructions
 ### 1️⃣ Clone the Repository
    ```sh
-   git clone https://github.com/your-username/dwm-arch.git
+   git clone https://github.com/stocky789/dwm-arch.git
    cd dwm-arch
    ```
 


### PR DESCRIPTION
## Summary
- fix README instruction to clone from correct GitHub repo

## Testing
- `bash -n install.sh`
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a54e7498088323a7dc32c7d9701fed